### PR TITLE
Use fs.writeFileSync to write snapshots

### DIFF
--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -74,8 +74,7 @@ class Snapshot {
             escape(this.snapshot[s])
           }\n\`\n`).join('\n'))
       fs.mkdirSync(path.dirname(this.file), {recursive: true})
-      const writeFile = require('write-file-atomic')
-      writeFile.sync(this.file, data, 'utf8')
+      fs.writeFileSync(this.file, data, 'utf8')
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -619,7 +619,8 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
     },
     "indent-string": {
       "version": "4.0.0",
@@ -656,7 +657,8 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-windows": {
       "version": "1.0.2",
@@ -1326,6 +1328,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
       "requires": {
         "is-typedarray": "^1.0.0"
       }
@@ -1438,6 +1441,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.1.tgz",
       "integrity": "sha512-JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==",
+      "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4",
         "is-typedarray": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "tap-yaml": "^1.0.0",
     "tcompare": "^3.0.0",
     "trivial-deferred": "^1.0.1",
-    "write-file-atomic": "^3.0.1",
     "yapool": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I didn't want to sneak this in.  Is the use of atomic write a situation of "over-engineering" or is there a situation where you think this could matter?