### PR TITLE
Add `output` option to `libtap/settings`.

### DIFF
--- a/lib/tap.js
+++ b/lib/tap.js
@@ -31,7 +31,7 @@ if (!settings.output) {
 
 const monkeypatchEpipe = () => {
   const emit = settings.output.emit
-  settings.output.emit = function (ev, er) {
+  settings.output.emit = function (ev, er = {}) {
     if (ev !== 'error' || er.code !== 'EPIPE')
       return emit.apply(settings.output, arguments)
   }

--- a/lib/tap.js
+++ b/lib/tap.js
@@ -7,6 +7,7 @@ const objToYaml = require('./obj-to-yaml.js')
 const _didPipe = Symbol('_didPipe')
 const _unmagicPipe = Symbol('_unmagicPipe')
 const Domain = require('async-hook-domain')
+const settings = require('../settings.js')
 
 let processPatched = false
 const rootDomain = new Domain((er, type) => {
@@ -21,7 +22,7 @@ const rootDomain = new Domain((er, type) => {
 })
 
 /* istanbul ignore next */
-if (!process.stdout) {
+if (!settings.output) {
   // Set exitCode in case process.stderr is also invalid
   process.exitCode = 1
   console.error('Output stream is invalid')
@@ -29,10 +30,10 @@ if (!process.stdout) {
 }
 
 const monkeypatchEpipe = () => {
-  const emit = process.stdout.emit
-  process.stdout.emit = function (ev, er) {
+  const emit = settings.output.emit
+  settings.output.emit = function (ev, er) {
     if (ev !== 'error' || er.code !== 'EPIPE')
-      return emit.apply(process.stdout, arguments)
+      return emit.apply(settings.output, arguments)
   }
 }
 
@@ -89,7 +90,7 @@ class TAP extends Test {
   write (c, e) {
     // this resets write and pipe to standard values
     this.patchProcess()
-    this.pipe(process.stdout)
+    this.pipe(settings.output)
     return super.write(c, e)
   }
 
@@ -172,6 +173,7 @@ onExit((code, signal) => {
     return
 
   const handles = process._getActiveHandles().filter(h =>
+    h !== settings.output &&
     h !== process.stdout &&
     h !== process.stdin &&
     h !== process.stderr

--- a/settings.js
+++ b/settings.js
@@ -26,7 +26,8 @@ module.exports = {
     // Support `settings.stackUtils.internals.push()`
     internals: StackUtils.nodeInternals(),
     ignoredPackages: []
-  }
+  },
+  output: process.stdout
 }
 
 function initRmdir() {

--- a/tap-snapshots/test-settings.js-TAP.test.js
+++ b/tap-snapshots/test-settings.js-TAP.test.js
@@ -8,6 +8,7 @@
 exports[`test/settings.js TAP > must match snapshot 1`] = `
 Object {
   "atTap": false,
+  "output": "process.stdout",
   "rmdirRecursiveSync": Function rmdirRecursiveSync(dir),
   "stackUtils": Object {
     "ignoredPackages": Array [],

--- a/tap-snapshots/test-tap-redirect-output-emit-undefined-error.js-TAP.test.js
+++ b/tap-snapshots/test-tap-redirect-output-emit-undefined-error.js-TAP.test.js
@@ -1,0 +1,22 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/tap/redirect-output-emit-undefined-error.js TAP > exit status 1`] = `
+Object {
+  "code": 0,
+  "signal": null,
+}
+`
+
+exports[`test/tap/redirect-output-emit-undefined-error.js TAP > stderr 1`] = `
+
+`
+
+exports[`test/tap/redirect-output-emit-undefined-error.js TAP > stdout 1`] = `
+error with 0 arguments emitted
+
+`

--- a/tap-snapshots/test-tap-redirect-output.js-TAP.test.js
+++ b/tap-snapshots/test-tap-redirect-output.js-TAP.test.js
@@ -1,0 +1,25 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/tap/redirect-output.js TAP > exit status 1`] = `
+Object {
+  "code": 0,
+  "signal": null,
+}
+`
+
+exports[`test/tap/redirect-output.js TAP > stderr 1`] = `
+
+`
+
+exports[`test/tap/redirect-output.js TAP > stdout 1`] = `
+redirected: TAP version 13
+redirected: ok 1 - ok
+redirected: 1..1
+redirected: # {time}
+
+`

--- a/test/settings.js
+++ b/test/settings.js
@@ -5,9 +5,11 @@ const {rmdirRecursiveSync} = settings
 
 t.ok(Array.isArray(settings.stackUtils.internals), 'Array.isArray(settings.stackUtils.internals)')
 t.not(settings.stackUtils.internals.length, 0)
+t.equal(settings.output, process.stdout)
 
 t.matchSnapshot({
   ...settings,
+  output: 'process.stdout',
   stackUtils: {
     ...settings.stackUtils,
     internals: []

--- a/test/tap/redirect-output-emit-undefined-error.js
+++ b/test/tap/redirect-output-emit-undefined-error.js
@@ -1,0 +1,19 @@
+require('./')(
+  () => {
+    const {writeSync} = require('fs')
+    const {PassThrough} = require('stream')
+    const settings = require('../../settings.js')
+    settings.output = new PassThrough()
+    // Verify the local process can intercept libtap output
+    settings.output.on('error', (...args) => {
+      writeSync(1, `error with ${args.length} arguments emitted\n`);
+    })
+    settings.output.on('data', data => {
+      writeSync(1, 'redirected: ' + data.toString())
+    })
+  },
+  () => {
+    const settings = require('../../settings.js')
+    settings.output.emit('error')
+  }
+)

--- a/test/tap/redirect-output.js
+++ b/test/tap/redirect-output.js
@@ -1,0 +1,14 @@
+require('./')(
+  () => {
+    const {writeSync} = require('fs')
+    const {PassThrough} = require('stream')
+    const settings = require('../../settings.js')
+    settings.output = new PassThrough()
+    const results = []
+    // Verify the local process can intercept libtap output
+    settings.output.on('data', data => {
+      writeSync(1, 'redirected: ' + data.toString())
+    })
+  },
+  t => t.pass('ok')
+)


### PR DESCRIPTION
This defaults to `process.stdout` but can be altered.  This is primarily
to allow custom test runners to pipe test output directly to a reporter
without additional processes.