### PR TITLE
Remove direct support for rimraf

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,22 @@ edge cases it can be appropriate to use `libtap` directly.
 
 ### Recursive rmdir
 
-Some parts of `libtap` require a recursive rmdirSync function.  In node.js 12.10.0+
+Some parts of `libtap` require a recursive rmdirSync function.  In Node.js 12.10.0+
 the default implementation is `dir => fs.rmdirSync(dir, {recursive: true})`.  For older
-versions of node.js you must either install `rimraf` or set
-`require('libtap/settings').rmdirRecursiveSync` with another implementation.  `tap`
-installs `rimraf` unconditionally so this is only a concern to direct `libtap` users
-who support older versions of node.js.
+versions of Node.js you must set `require('libtap/settings').rmdirRecursiveSync` with a
+compatible function.  This function must be synchronous and have a single parameter:
+
+```js
+const rimraf = require('rimraf').sync
+const settings = require('libtap/settings')
+settings.rmdirRecursiveSync = dir => rimraf(dir, {glob: false})
+```
+
+This is handled by `tap` so only direct users of `libtap` who need to support older
+versions of Node.js need to worry about this.
 
 It is not considered semver-major for a libtap function to use recursive rmdir where
-it previously did not.  If you test on older versions of node.js then you must ensure
+it previously did not.  If you test on older versions of Node.js then you must ensure
 a user-space implementation is available even if it is not currently needed.
 
 ## Environmental changes still in place

--- a/tap-snapshots/test-settings.js-TAP.test.cjs
+++ b/tap-snapshots/test-settings.js-TAP.test.cjs
@@ -9,6 +9,7 @@ exports[`test/settings.js TAP > must match snapshot 1`] = `
 Object {
   "atTap": false,
   "output": "process.stdout",
+  "rimrafNeeded": "version specific",
   "rmdirRecursiveSync": Function rmdirRecursiveSync(dir),
   "stackUtils": Object {
     "ignoredPackages": Array [],

--- a/test/fixture.js
+++ b/test/fixture.js
@@ -1,8 +1,15 @@
 const t = require('../')
 const Fixture = require('../lib/fixture.js')
-const {rmdirRecursiveSync} = require('../settings.js')
+const settings = require('../settings.js')
 
 const dir = t.testdirName
+
+if (settings.rimrafNeeded) {
+  settings.rmdirRecursiveSync = dir => require('rimraf').sync(dir, {glob: false})
+}
+
+settings.rmdirRecursiveSync(dir)
+
 const f = new Fixture('file', 'bar')
 t.match(f, {
   type: 'file',
@@ -45,4 +52,4 @@ t.match(fs.statSync(`${dir}/link`), fs.statSync(`${dir}/file`),
   'hardlink is hard link')
 t.equal(fs.readlinkSync(`${dir}/symlink`), 'file', 'symlink is symlink')
 t.ok(fs.statSync(`${dir}/dir`).isDirectory(), 'subdir is a dir')
-rmdirRecursiveSync(dir)
+settings.rmdirRecursiveSync(dir)

--- a/test/settings.js
+++ b/test/settings.js
@@ -1,14 +1,16 @@
 'use strict'
 const t = require('../')
 const settings = require('../settings.js')
-const {rmdirRecursiveSync} = settings
 
 t.ok(Array.isArray(settings.stackUtils.internals), 'Array.isArray(settings.stackUtils.internals)')
+t.type(settings.rimrafNeeded, 'boolean')
 t.not(settings.stackUtils.internals.length, 0)
 t.equal(settings.output, process.stdout)
 
 t.matchSnapshot({
   ...settings,
+  rimrafNeeded: 'version specific',
+  rmdirRecursiveSync(dir) {},
   output: 'process.stdout',
   stackUtils: {
     ...settings.stackUtils,
@@ -26,5 +28,5 @@ t.throws(_ => {
 
 const replacement = dir => {}
 settings.rmdirRecursiveSync = replacement
+t.equal(settings.rimrafNeeded, false)
 t.equal(settings.rmdirRecursiveSync, replacement)
-settings.rmdirRecursiveSync = rmdirRecursiveSync

--- a/test/snapshot.js
+++ b/test/snapshot.js
@@ -1,13 +1,18 @@
 'use strict'
 const t = require('../')
 const Snapshot = require('../lib/snapshot.js')
-const {rmdirRecursiveSync} = require('../settings.js')
+const settings = require('../settings.js')
 const path = require('path')
 const dir = path.resolve(__dirname, 'snapshot')
 const fs = require('fs')
 
+if (settings.rimrafNeeded) {
+  settings.rmdirRecursiveSync = dir => require('rimraf').sync(dir, {glob: false})
+}
+
 t.test('cleanup first', t => {
-  rmdirRecursiveSync(dir)
+  settings.rmdirRecursiveSync(dir)
+
   fs.mkdirSync(dir, {recursive: true})
   process.chdir(dir)
   t.end()
@@ -53,7 +58,7 @@ t.test('actual test', t => {
 })
 
 t.test('cleanup after', t => {
-  rmdirRecursiveSync(dir)
+  settings.rmdirRecursiveSync(dir)
   process.chdir(__dirname)
   t.end()
 })

--- a/test/test.js
+++ b/test/test.js
@@ -7,7 +7,11 @@ const util = require('util')
 const assert = require('assert')
 const EE = require('events').EventEmitter
 const MiniPass = require('minipass')
-const {rmdirRecursiveSync} = require('../settings.js')
+const settings = require('../settings.js')
+
+if (settings.rimrafNeeded) {
+  settings.rmdirRecursiveSync = dir => require('rimraf').sync(dir, {glob: false})
+}
 
 // set this forcibly so it doesn't interfere with other tests.
 process.env.TAP_DIAG = ''
@@ -1214,7 +1218,7 @@ t.test('save a fixture', t => {
   let leaveDir
   t.test('leave the dir behind', { saveFixture: true }, t => {
     leaveDir = t.testdir()
-    t.parent.teardown(() => rmdirRecursiveSync(leaveDir))
+    t.parent.teardown(() => settings.rmdirRecursiveSync(leaveDir))
     t.end()
   })
   t.ok(fs.statSync(leaveDir).isDirectory(), 'left dir behind')


### PR DESCRIPTION
Users of this module will need to set the function on their own if
needed.  This allows better compatibility with systems such as yarn pnp
where `libtap` might not be able to `require('rimraf')` without directly
depending on it.