### PR TITLE
Resolve `no-unused-vars` issues, group `require` statements

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -1,13 +1,14 @@
 'use strict'
 
-const MiniPass = require('minipass')
-
-const extraFromError = require('./extra-from-error.js')
 const assert = require('assert')
-
-const Domain = require('async-hook-domain')
-const {AsyncResource} = require('async_hooks')
 const util = require('util')
+const {AsyncResource} = require('async_hooks')
+const MiniPass = require('minipass')
+const Domain = require('async-hook-domain')
+const Parser = require('tap-parser')
+const ownOr = require('own-or')
+const ownOrEnv = require('own-or-env')
+const extraFromError = require('./extra-from-error.js')
 
 class TapWrap extends AsyncResource {
   constructor (test) {
@@ -15,11 +16,6 @@ class TapWrap extends AsyncResource {
     this.test = test
   }
 }
-
-const Parser = require('tap-parser')
-
-const ownOr = require('own-or')
-const ownOrEnv = require('own-or-env')
 
 class Base extends MiniPass {
   constructor (options) {
@@ -107,7 +103,7 @@ class Base extends MiniPass {
     return this.parser.ok
   }
 
-  setTimeout (n, quiet) {
+  setTimeout (n) {
     if (!this.hrtime)
       this.hrtime = process.hrtime()
 
@@ -163,7 +159,6 @@ class Base extends MiniPass {
 
   timeout (options) {
     this.setTimeout(false)
-    const er = new Error('timeout!')
     options = options || {}
     options.expired = options.expired || this.name
     this.emit('timeout', this.threw(new Error('timeout!'), options))
@@ -262,7 +257,7 @@ class Base extends MiniPass {
     this.parser.on('complete', result => this.oncomplete(result))
 
     this.parser.on('result', () => this.counts.total++)
-    this.parser.on('pass', res => this.counts.pass++)
+    this.parser.on('pass', () => this.counts.pass++)
     this.parser.on('todo', res => {
       this.counts.todo++
       this.lists.todo.push(res)

--- a/lib/clean-yaml-object.js
+++ b/lib/clean-yaml-object.js
@@ -1,18 +1,14 @@
 'use strict'
 const path = require('path')
-const Module = require('module')
 const fs = require('fs')
-const binpath = path.resolve(__dirname, '../bin')
-const stack = require('./stack.js')
 const diff = require('diff')
-const yaml = require('tap-yaml')
 const {format, strict} = require('tcompare')
+const stack = require('./stack.js')
 const settings = require('../settings')
 
 const hasOwn = (obj, key) =>
   Object.prototype.hasOwnProperty.call(obj, key)
 
-const tapDir = path.resolve(__dirname, '..')
 const cleanDiag = object => {
   const res = { ...object }
   if (hasOwn(res, 'stack') && !hasOwn(res, 'at'))
@@ -28,7 +24,7 @@ const cleanDiag = object => {
     const content = (() => {
       try {
         return fs.readFileSync(file, 'utf8')
-      } catch (er) {
+      } catch {
       }
     })()
     if (content) {

--- a/lib/extra-from-error.js
+++ b/lib/extra-from-error.js
@@ -20,7 +20,6 @@ module.exports = (er, extra, options) => {
   const message = er.message ? er.message
     : er.stack ? er.stack.split('\n')[0]
     : ''
-  const addName = er.message || !er.stack
 
   if (er.message) {
     try {
@@ -28,7 +27,7 @@ module.exports = (er, extra, options) => {
         value: '',
         configurable: true
       })
-    } catch (e) {}
+    } catch {}
   }
 
   const st = er.stack && er.stack.substr(
@@ -62,7 +61,7 @@ module.exports = (er, extra, options) => {
         value: message,
         configurable: true
       })
-    } catch (e) {}
+    } catch {}
   }
 
   if (er.name && er.name !== 'Error')

--- a/lib/obj-to-yaml.js
+++ b/lib/obj-to-yaml.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const cleanYamlObject = require('./clean-yaml-object.js')
 const yaml = require('tap-yaml')
+const cleanYamlObject = require('./clean-yaml-object.js')
 
 module.exports = obj => (clean =>
   (clean && typeof clean === 'object' && Object.keys(clean).length) ?

--- a/lib/point.js
+++ b/lib/point.js
@@ -1,8 +1,4 @@
 'use strict'
-
-const path = require('path')
-const binpath = path.resolve(__dirname, '../bin')
-const util = require('util')
 const diags = require('./diags.js')
 
 class TestPoint {

--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -23,7 +23,7 @@ class Snapshot {
     this.indexes.set(message, index + 1)
     try {
       this.snapshot = this.snapshot || require(this.file)
-    } catch (er) {
+    } catch {
       throw new Error(
         'Snapshot file not found: ' + this.file + '\n' +
         'Run with TAP_SNAPSHOT=1 in the environment\n' +

--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -1,12 +1,9 @@
 'use strict'
-const Base = require('./base.js')
-
-const assert = require('assert')
-const util = require('util')
-const ownOr = require('own-or')
 const path = require('path')
-const cleanYamlObject = require('./clean-yaml-object.js')
 const cp = require('child_process')
+const ownOr = require('own-or')
+const Base = require('./base.js')
+const cleanYamlObject = require('./clean-yaml-object.js')
 
 class Spawn extends Base {
   constructor (options) {

--- a/lib/stdin.js
+++ b/lib/stdin.js
@@ -1,6 +1,6 @@
 'use strict'
-const Base = require('./base.js')
 const ownOr = require('own-or')
+const Base = require('./base.js')
 
 class Stdin extends Base {
   constructor (options) {

--- a/lib/tap.js
+++ b/lib/tap.js
@@ -1,15 +1,17 @@
 'use strict'
+const Domain = require('async-hook-domain')
+const onExit = require('signal-exit')
 const Test = require('./test.js')
 const Stdin = require('./stdin.js')
 const Spawn = require('./spawn.js')
-const util = require('util')
 const objToYaml = require('./obj-to-yaml.js')
-const _didPipe = Symbol('_didPipe')
-const _unmagicPipe = Symbol('_unmagicPipe')
-const Domain = require('async-hook-domain')
 const settings = require('../settings.js')
 
+const _didPipe = Symbol('_didPipe')
+const _unmagicPipe = Symbol('_unmagicPipe')
+
 let processPatched = false
+/* eslint-disable-next-line no-unused-vars -- created for side-effects */
 const rootDomain = new Domain((er, type) => {
   if (!processPatched)
     throw er
@@ -166,7 +168,6 @@ tap.Spawn = Spawn
 tap.Stdin = Stdin
 
 // SIGTERM means being forcibly killed, almost always by timeout
-const onExit = require('signal-exit')
 let didTimeoutKill = false
 onExit((code, signal) => {
   if (signal !== 'SIGTERM' || !tap[_didPipe] || didTimeoutKill)

--- a/lib/test.js
+++ b/lib/test.js
@@ -17,29 +17,32 @@
 // encounter an unfinished test.  When we encounter ANY kind of test, we
 // block until its output is completed, dumping it all into the parser.
 
-const {format, same, strict, match, hasStrict} = require('tcompare')
-const formatSnapshotDefault = obj => format(obj, { sort: true })
-const Base = require('./base.js')
-const Spawn = require('./spawn.js')
-const Stdin = require('./stdin.js')
-const Deferred = require('trivial-deferred')
-const Pool = require('yapool')
-const TestPoint = require('./point.js')
-const parseTestArgs = require('./parse-test-args.js')
-const loop = require('function-loop')
 const path = require('path')
-const fs = require('fs')
-const Fixture = require('./fixture.js')
-const cleanYamlObject = require('./clean-yaml-object.js')
-
-const extraFromError = require('./extra-from-error.js')
-const stack = require('./stack.js')
-const settings = require('../settings.js')
 const assert = require('assert')
 const util = require('util')
+
+const {format, same, strict, match, hasStrict} = require('tcompare')
+const Deferred = require('trivial-deferred')
+const loop = require('function-loop')
+const Pool = require('yapool')
 const ownOr = require('own-or')
 const ownOrEnv = require('own-or-env')
 const bindObj = require('bind-obj-methods')
+
+const Base = require('./base.js')
+const Spawn = require('./spawn.js')
+const Stdin = require('./stdin.js')
+const TestPoint = require('./point.js')
+const parseTestArgs = require('./parse-test-args.js')
+const Fixture = require('./fixture.js')
+const cleanYamlObject = require('./clean-yaml-object.js')
+const extraFromError = require('./extra-from-error.js')
+const stack = require('./stack.js')
+const settings = require('../settings.js')
+const Snapshot = require('./snapshot.js')
+const Waiter = require('./waiter.js')
+
+const formatSnapshotDefault = obj => format(obj, { sort: true })
 const cwd = process.cwd()
 
 // A sigil object for implicit end() calls that should not
@@ -57,8 +60,6 @@ const _beforeEnd = Symbol('_beforeEnd')
 const _emits = Symbol('_emits')
 const _nextChildId = Symbol('_nextChildId')
 const _expectUncaught = Symbol('_expectUncaught')
-const Snapshot = require('./snapshot.js')
-const Waiter = require('./waiter.js')
 
 const hasOwn = (obj, key) =>
   Object.prototype.hasOwnProperty.call(obj, key)
@@ -1298,7 +1299,7 @@ class Test extends Base {
   }
 
   expectUncaughtException (...args) {
-    let [_, ...rest] = this.throwsArgs('expect uncaughtException', ...args)
+    let [, ...rest] = this.throwsArgs('expect uncaughtException', ...args)
     this[_expectUncaught].push(rest)
   }
 


### PR DESCRIPTION
`require` statements are grouped by source type:
1. Node.js builtin modules
2. npm modules
3. relative modules