### PR TITLE
Adds `t.mock()` API

### DIFF
--- a/lib/mock.js
+++ b/lib/mock.js
@@ -1,0 +1,84 @@
+const Module = require('module')
+const { isAbsolute } = require('path')
+
+const isPlainObject = obj => obj
+  && typeof obj === 'object'
+  && (Object.getPrototypeOf(obj) === null
+    || Object.getPrototypeOf(obj) === Object.prototype)
+
+class Mock {
+  constructor(parentFilename, filename, mocks = {}) {
+    this.filename = filename
+    this.mocks = new Map()
+
+    if (!parentFilename || typeof parentFilename !== 'string') {
+      throw new TypeError('A parentFilename is required to resolve Mocks paths')
+    }
+
+    if (!filename || typeof filename !== 'string') {
+      throw new TypeError('t.mock() first argument should be a string')
+    }
+
+    if (!isPlainObject(mocks)) {
+      throw new TypeError(
+        'mocks should be a a key/value object in which keys ' +
+        `are the same used in ${filename} require calls`
+      )
+    }
+
+    const self = this
+    const callerTestRef = Module._cache[parentFilename]
+    const filePath = Module._resolveFilename(filename, callerTestRef)
+
+    // populate mocks Map from resolved filenames
+    for (const key of Object.keys(mocks)) {
+      const mockFilePath = Module._resolveFilename(key, callerTestRef)
+      this.mocks.set(mockFilePath, mocks[key])
+    }
+
+    // keep a cache system for non-mocked files
+    const seen = new Map()
+
+    class MockedModule extends Module {
+      require (id) {
+        const requiredFilePath = Module._resolveFilename(id, this)
+
+        // if it's a mocked file, just serve that instead
+        if (self.mocks.has(requiredFilePath))
+          return self.mocks.get(requiredFilePath)
+
+        // builtin, not-mocked modules need to be loaded via regular require fn
+        const isWindows = process.platform === 'win32';
+        /* istanbul ignore next - platform dependent code path */
+        const isRelative = id.startsWith('./') ||
+          id.startsWith('../') ||
+          ((isWindows && id.startsWith('.\\')) ||
+          id.startsWith('..\\'))
+        if (!isRelative && !isAbsolute(id))
+          return super.require(id)
+
+        // if non-mocked file that we've seen, return that instead
+        // this enable cicle-required deps to work
+        if (seen.has(requiredFilePath))
+          return seen.get(requiredFilePath).exports
+
+        // load any not-mocked module via our MockedModule class
+        // also sets them in our t.mock realm cache to avoid cicles
+        const unmockedModule = new MockedModule(requiredFilePath, this)
+        seen.set(requiredFilePath, unmockedModule)
+        unmockedModule.load(requiredFilePath)
+        return unmockedModule.exports
+      }
+    }
+
+    this.module = new MockedModule(filePath, callerTestRef)
+    this.module.load(filePath)
+  }
+
+  static get(parentFilename, filename, mocks) {
+    const mock = new Mock(parentFilename, filename, mocks)
+    return mock.module.exports
+  }
+}
+
+module.exports = Mock

--- a/lib/test.js
+++ b/lib/test.js
@@ -35,6 +35,7 @@ const Stdin = require('./stdin.js')
 const TestPoint = require('./point.js')
 const parseTestArgs = require('./parse-test-args.js')
 const Fixture = require('./fixture.js')
+const Mock = require('./mock.js')
 const cleanYamlObject = require('./clean-yaml-object.js')
 const extraFromError = require('./extra-from-error.js')
 const stack = require('./stack.js')
@@ -1187,6 +1188,12 @@ class Test extends Base {
 
   fixture (type, content) {
     return new Fixture(type, content)
+  }
+
+  mock (module, mocks) {
+    const {file} = stack.at(Test.prototype.mock)
+    const resolved = path.resolve(file)
+    return Mock.get(resolved, module, mocks)
   }
 
   matchSnapshot (found, message, extra) {

--- a/test/mock.js
+++ b/test/mock.js
@@ -1,0 +1,175 @@
+const { resolve } = require('path')
+const t = require('../')
+const Mock = require('../lib/mock.js')
+const settings = require('../settings.js')
+
+if (settings.rimrafNeeded) {
+  settings.rmdirRecursiveSync = dir => require('rimraf').sync(dir, {glob: false})
+  settings.rmdirRecursive = (dir, cb) => require('rimraf')(dir, {glob: false}, cb)
+}
+
+t.throws(
+  () => Mock.get(),
+  'A parentFilename is required to resolve Mocks paths',
+  'should throw on missing parentFilename',
+)
+
+t.throws(
+  () => Mock.get(__filename),
+  /first argument should be a string/,
+  'should throw on invalid filename',
+)
+
+t.throws(
+  () => Mock.get(__filename, './foo.js', ''),
+  /mocks should be a a key\/value object in which keys/,
+  'should throw on invalid mock-defining object',
+)
+
+t.throws(
+  () => Mock.get(__filename, './foo.js', [1]),
+  /mocks should be a a key\/value object in which keys/,
+  'should throw on invalid mock-defining object',
+)
+
+t.throws(
+  () => Mock.get(__filename, './foo.js', null),
+  /mocks should be a a key\/value object in which keys/,
+  'should throw on invalid mock-defining object',
+)
+
+t.throws(
+  () => Mock.get(__filename, './foo.js', /foo/),
+  /mocks should be a a key\/value object in which keys/,
+  'should throw on invalid mock-defining object',
+)
+
+t.throws(
+  () => Mock.get(__filename, './foo.js', 1),
+  /mocks should be a a key\/value object in which keys/,
+  'should throw on invalid mock-defining object',
+)
+
+t.throws(
+  () => Mock.get(__filename, './foo.js', new Map()),
+  /mocks should be a a key\/value object in which keys/,
+  'should throw on invalid mock-defining object',
+)
+
+t.test('mock', t => {
+  const path = t.testdir({
+    node_modules: {
+      lorem: {
+        'package.json': JSON.stringify({ name: 'lorem' }),
+        'index.js': `module.exports = function () { return 'lorem' }`,
+      },
+    },
+    lib: {
+      'a.js': `
+        const { inspect } = require('util');
+        const lorem = require('lorem');
+        const b = require('./b.js');
+        const c = require('./utils/c');
+        const d = require('../helpers/d.js');
+        const f = require('../f.cjs');
+        module.exports = function() {
+          return [inspect, lorem, b, c, d, f, require('../g.js')]
+            .map(i => i({})).join(' ')
+        };
+        `,
+      'b.js': `module.exports = function () { return 'b' }`,
+      utils: {
+        'c.js': `module.exports = function () { return 'c' }`
+      },
+    },
+    helpers: {
+      'd.js': `
+        const e = require('./e.js');
+        module.exports = function () { return ['d', e()].join(' ') }`,
+      'e.js': `module.exports = function () { return 'e' }`,
+    },
+    'f.cjs': `module.exports = function () { return 'f' }`,
+    'g.js': `module.exports = function () { return 'g' }`,
+    'h.js': `module.exports = require.resolve('./g.js')`,
+    'i.js': `module.exports = require('./j.js') + require('./k.js')`,
+    'j.js': `module.exports = require('./k.js')`,
+    'k.js': `module.exports = 'k'`,
+  })
+
+  t.equal(
+    Mock.get(__filename, resolve(path, 'lib/a.js'), {
+      [resolve(path, 'lib/b.js')]: () => 'foo',
+    })(),
+    '{} lorem foo c d e f g',
+    'should use injected version of a mock',
+  )
+
+  t.equal(
+    require(resolve(path, 'lib/a.js'))(),
+    '{} lorem b c d e f g',
+    'should be able to use original module post-mocking',
+  )
+
+  t.equal(
+    Mock.get(__filename, resolve(path, 'lib/a.js'), {
+      [resolve(path, 'helpers/d.js')]: () => 'bar',
+    })(),
+    '{} lorem b c bar f g',
+    'should mock module not located under the same parent folder',
+  )
+
+  t.equal(
+    Mock.get(__filename, resolve(path, 'lib/a.js'), {
+      [resolve(path, 'f.cjs')]: () => 'bar',
+    })(),
+    '{} lorem b c d e bar g',
+    'should mock module using cjs extension',
+  )
+
+  t.equal(
+    Mock.get(__filename, resolve(path, 'lib/a.js'), {
+      [resolve(path, 'lib/b.js')]: () => 'foo',
+      [resolve(path, 'lib/utils/c')]: () => 'bar',
+    })(),
+    '{} lorem foo bar d e f g',
+    'should mock nested module',
+  )
+
+  t.equal(
+    Mock.get(__filename, resolve(path, 'lib/a.js'), {
+      util: { inspect: obj => obj.constructor.prototype },
+    })(),
+    '[object Object] lorem b c d e f g',
+    'should mock builtin module',
+  )
+
+  t.equal(
+    require(resolve(path, 'lib/a.js'))(),
+    '{} lorem b c d e f g',
+    'should preserve original module after mocking',
+  )
+
+  t.equal(
+    Mock.get(__filename, resolve(path, 'h.js')),
+    resolve(path, 'g.js'),
+    'should preserve require properties and methods',
+  )
+
+  t.equal(
+    Mock.get(__filename, resolve(path, 'i.js')),
+    'kk',
+    'should read non-mocked cached modules from t.mock realm',
+  )
+
+  // lorem is an unknown module id in the context of the current script,
+  // trying to mock it will result in an error while trying to resolve
+  // the filename for generating the mocks map
+  t.throws(
+    () => Mock.get(__filename, resolve(path, 'lib/a.js'), {
+      lorem: () => '***',
+    })(),
+    { code: 'MODULE_NOT_FOUND' },
+    'can only mock known installed modules',
+  )
+  t.end()
+})

--- a/test/test.js
+++ b/test/test.js
@@ -1236,3 +1236,326 @@ t.test('fixture dir stuff', t => {
   })
   t.end()
 })
+
+t.test('require defining mocks', t => {
+  // require/mock some actual internal tap modules
+  const diags = t.mock('../lib/diags.js', {
+    '../lib/obj-to-yaml.js': a => `foo ${a}`,
+  })
+  t.equal(diags('bar'), '\nfoo bar', 'should mock actual lib file')
+
+  // stress test common js require injection logic
+  t.test('same level files', t => {
+    const f = t.testdir({
+      'a.js': 'module.exports = "a"',
+      'index.js': 'const a = require("./a.js"); module.exports = () => a',
+      'test.js':
+        `const t = require('../..'); // tap
+        t.test('mock file at same level', t => {
+          const i = t.mock('./index.js', {
+            './a.js': 'mocked-a',
+          })
+          t.equal(i(), 'mocked-a', 'should get mocked result')
+          t.end()
+        })`,
+    })
+    return t.spawn(
+      process.execPath,
+      [ path.resolve(f, 'test.js') ],
+      { cwd: f },
+    )
+  })
+
+  t.test('immediately called require', t => {
+    const f = t.testdir({
+      'a.js': 'module.exports = () => { global.foo = true }',
+      'index.js': 'require("./a.js")()',
+      'test.js':
+        `const t = require('../..'); // tap
+        t.test('mock immediately called require', t => {
+          t.mock('./index.js', {
+            './a.js': () => {
+              t.notOk(global.foo, 'should not run original a.js')
+              t.end()
+            }
+          })
+        })`,
+    })
+    return t.spawn(
+      process.execPath,
+      [ path.resolve(f, 'test.js') ],
+      { cwd: f },
+    )
+  })
+
+  t.test('run-time invoked require call', t => {
+    const f = t.testdir({
+      'a.js': 'module.exports = "a"',
+        'index.js': 'module.exports = () => { return require("./a.js") }',
+      'test.js':
+        `const t = require('../..'); // tap
+        t.test('mock file at run time', t => {
+          const i = t.mock('./index.js', {
+            './a.js': 'mocked-a',
+          })
+          t.equal(i(), 'mocked-a', 'should get mocked result')
+          t.end()
+        })`,
+    })
+    return t.spawn(
+      process.execPath,
+      [ path.resolve(f, 'test.js') ],
+      { cwd: f },
+    )
+  })
+
+  t.test('nested lib files', t => {
+    const f = t.testdir({
+      lib: {
+        'a.js': 'module.exports = "a"',
+      },
+      'index.js': 'const a = require("./lib/a"); module.exports = () => a',
+      'test.js':
+        `const t = require('../..'); // tap
+        t.test('mock file at nested lib', t => {
+          const i = t.mock('./index.js', {
+            './lib/a.js': 'mocked-a',
+          })
+          t.equal(i(), 'mocked-a', 'should get mocked result')
+          t.end()
+        })`,
+    })
+    return t.spawn(
+      process.execPath,
+      [ path.resolve(f, 'test.js') ],
+      { cwd: f },
+    )
+  })
+
+  t.test('nested test/lib files', t => {
+    const f = t.testdir({
+      lib: {
+        'a.js': 'module.exports = "a"',
+        'b.js': 'module.exports = "b"',
+        'c.js':
+          `const a = require('./a.js')
+          const b = require('./b.js')
+          const d = require('./utils/d')
+          module.exports = [a, b, d].join(' ')`,
+        utils: {
+          'd.js': 'module.exports = "d"',
+        },
+      },
+      'index.js':
+        `const a = require("./lib/a")
+        const b = require('./lib/b.js')
+        const c = require('./lib/c.js')
+        const d = require("./lib/utils/d.js")
+        module.exports = () => [a, b, c, d].join(' ')`,
+      test: {
+        'test.js':
+          `const t = require('../../..'); // tap
+          t.test('mock file at nested lib', t => {
+            const i = t.mock('../index.js', {
+              '../lib/a.js': 'mocked-a',
+            })
+            t.equal(i(), 'mocked-a b mocked-a b d d', 'should get expected mocked result')
+            t.end()
+          })
+
+          t.test('mock file at nested lib from nested lib', t => {
+            const c = t.mock('../lib/c.js', {
+              '../lib/a.js': 'mocked-a',
+            })
+            t.equal(c, 'mocked-a b d', 'should get expected mocked result')
+            t.end()
+          })
+
+          t.test('mock a mock', t => {
+            const i = t.mock('../index.js', {
+              '../lib/a.js': 'mocked-a',
+              '../lib/c.js': t.mock('../lib/c.js', {
+                '../lib/b': 'mocked-b-within-c'
+              })
+            })
+            t.equal(i(), 'mocked-a b a mocked-b-within-c d d', 'should get expected mocked-mocked result')
+            t.end()
+          })`,
+      },
+    })
+    return t.spawn(
+      process.execPath,
+      [ path.resolve(f, 'test', 'test.js') ],
+      { cwd: f },
+    )
+  })
+
+  t.test('runner wrapper', t => {
+    const f = t.testdir({
+      lib: {
+        'a.js': 'module.exports = "a"',
+      },
+      'index.js': 'const a = require("./lib/a.js"); module.exports = () => a',
+      test: {
+        runner: {
+          'index.js': 'require("../unit/test")',
+        },
+        unit: {
+          'test.js':
+            `const t = require('../../../..'); // tap
+            t.test('mock file started from a runner', t => {
+              const i = t.mock('../../index.js', {
+                '../../lib/a': 'mocked-a',
+              })
+              t.equal(i(), 'mocked-a', 'should get mocked result')
+              t.end()
+            })`,
+        }
+      }
+    })
+    return t.spawn(
+      process.execPath,
+      [ path.resolve(f, 'test', 'runner', 'index.js') ],
+      { cwd: f },
+    )
+  })
+
+  t.test('installed modules', t => {
+    const f = t.testdir({
+      node_modules: {
+        foo: {
+          'package.json': JSON.stringify({ name: 'foo', main: './index.js' }),
+          'index.js': 'module.exports = () => "foo"',
+        },
+        bar: {
+          'package.json': JSON.stringify({ name: 'bar', main: './index.js' }),
+          'index.js': 'module.exports = () => "bar"',
+        },
+      },
+      'index.js':
+        `const foo = require('foo')
+        const bar = require('bar')
+        module.exports = foo() + ' ' + bar()`,
+      'test.js':
+        `const t = require('../..'); // tap
+        t.test('mock installed modules', t => {
+          const i = t.mock('./index.js', {
+            'foo': () => 'mocked-foo',
+          })
+          t.equal(i, 'mocked-foo bar', 'should get expected mocked result')
+          t.end()
+        })`,
+    })
+    return t.spawn(
+      process.execPath,
+      [ path.resolve(f, 'test.js') ],
+      { cwd: f },
+    )
+  })
+
+  t.test('builtin modules', t => {
+    const f = t.testdir({
+      'index.js':
+        `const util = require('util')
+        module.exports = str => util.format('%s:%s', 'foo', str)`,
+      'test.js':
+        `const t = require('../..'); // tap
+        t.test('mock builtin modules', t => {
+          const i = t.mock('./index.js', {
+            'util': { format: () => 'mocked-util' },
+          })
+          t.equal(i('bar'), 'mocked-util', 'should get mocked result')
+          t.end()
+        })`,
+    })
+    return t.spawn(
+      process.execPath,
+      [ path.resolve(f, 'test.js') ],
+      { cwd: f },
+    )
+  })
+
+  t.test('should support mocking within nested deps', t => {
+    const f = t.testdir({
+      lib: {
+        'a.js':
+          `module.exports = require('./b.js')`,
+        'b.js':
+          `module.exports = require('./c.js')`,
+        'c.js':
+          `module.exports = () => 'c'`,
+      },
+      'test.js':
+        `const t = require('../..'); // tap
+        t.test('mocking deps of required modules', t => {
+          const a = t.mock('./lib/a.js', {
+            './lib/c.js': () => 'mocked-c',
+          })
+          t.equal(a(), 'mocked-c', 'should get mocked-c result')
+          t.end()
+        })`,
+    })
+    return t.spawn(
+      process.execPath,
+      [ path.resolve(f, 'test.js') ],
+      { cwd: f },
+    )
+  })
+
+  t.test('should support cicle require', t => {
+    const f = t.testdir({
+      lib: {
+        'a.js':
+          `module.exports = require('./b.js')`,
+        'b.js':
+          `const c = require('./c.js')
+          const b = () => 'b and ' + c
+          b.extra = 'BBB'
+          module.exports = () => 'b and ' + c`,
+        'c.js':
+          `const b = require('./b.js')
+          module.exports = () => 'c and ' + b.extra`,
+      },
+      'test.js':
+        `const t = require('../..'); // tap
+        t.test('mocking cicled required deps', t => {
+          const a = t.mock('./lib/a.js', {})
+          t.ok('should not explode')
+          t.end()
+        })`,
+    })
+    return t.spawn(
+      process.execPath,
+      [ path.resolve(f, 'test.js') ],
+      { cwd: f },
+    )
+  })
+
+  t.test('should support mocking builtin modules within nested deps', t => {
+    const f = t.testdir({
+      lib: {
+        'a.js':
+          `module.exports = require('./b.js')`,
+        'b.js':
+          `module.exports = require('./c.js')`,
+        'c.js':
+          `module.exports = () => require('fs')`,
+      },
+      'test.js':
+        `const t = require('../..'); // tap
+        t.test('mocking builtin modules in nested modules', t => {
+          const fs = {}
+          const a = t.mock('./lib/a.js', { fs })
+          t.equal(a(), fs, 'should get mocked fs result')
+          t.end()
+        })`,
+    })
+    return t.spawn(
+      process.execPath,
+      [ path.resolve(f, 'test.js') ],
+      { cwd: f },
+    )
+  })
+
+  t.end()
+})


### PR DESCRIPTION
This brings into **tap** the standard mocking system we have been using
across the ecosystem of packages from the npm cli which consists into
hijacking the `require` calls from a given module and defining whatever
mock we want via something as simple as a key/value object.

It's a very conscious decision to make it a very opinionated API, as
stated in https://github.com/tapjs/node-tap#tutti-i-gusti-sono-gusti -
focusing only on the pattern that have been the standard way we handle
mocks.

It builds on the initial draft work from @nlf (ref:
https://gist.github.com/nlf/52ca6adab49e5b3939ba37c7f0fc51c6) and
initial brainstorming of such an API with @mikemimik - thanks ❤️

Example:

```js
t.test('testing something, t => {
  const myModule = t.mock('../my-module.js', {
    fs: { readFileSync: () => 'foo' }
  })

  t.equal(myModule.bar(), 'foo', 'should receive expected content')
})
```

Credit: @ruyadorno, @nlf
Reviewed-by: @isaacs
PR-URL: https://github.com/tapjs/node-tap/pull/698
Closes: https://github.com/tapjs/node-tap/pull/698