### PR TITLE
Add tap-testdir- to the generated test dir folder

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -1166,8 +1166,10 @@ class Test extends Base {
     const re = /[^a-z0-9]+/ig
     if (!this.parent) {
       const main = findMainScript('TAP')
+      // put in a prefix in the dirname so do not inadvertently run it
+      // on a subsequent tap invocation, if it was saved.
       const dir = path.dirname(main)
-      const base = (path.basename(main).replace(/\.[^.]+$/, '')
+      const base = 'tap-testdir-' + (path.basename(main).replace(/\.[^.]+$/, '')
         + ' ' + process.argv.slice(2).join(' ')).trim()
       return dir + '/' + base.replace(re, '-')
     }

--- a/tap-snapshots/test-test.js-TAP.test.cjs
+++ b/tap-snapshots/test-test.js-TAP.test.cjs
@@ -3271,7 +3271,7 @@ exports[`test/test.js TAP test dir name does not throw when no main module is pr
 `
 
 exports[`test/test.js TAP test dir name does not throw when no main module is present > stdout 1`] = `
-./TAP
+./tap-testdir-TAP
 
 `
 


### PR DESCRIPTION
Based on #25, land that first

This allows node-tap to skip test fixture directories in its default
test file walk, so we don't inadvertently crawl through test fixture
directories trying to run files in subsequent test invocations.