### PR TITLE
separate t.match() and t.has()

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -21,7 +21,7 @@ const path = require('path')
 const assert = require('assert')
 const util = require('util')
 
-const {format, same, strict, match, hasStrict} = require('tcompare')
+const {format, same, strict, match, has, hasStrict} = require('tcompare')
 const Deferred = require('trivial-deferred')
 const loop = require('function-loop')
 const Pool = require('yapool')
@@ -1242,6 +1242,20 @@ class Test extends Base {
 
   cleanSnapshot (string) {
     return string
+  }
+
+  has (found, wanted, message, extra) {
+    [message, extra] = normalizeMessageExtra('should contain all provided fields', message, extra)
+    this.currentAssert = Test.prototype.has
+
+    const s = has(found, wanted)
+    if (!s.match)
+      extra.diff = s.diff
+    else {
+      extra.found = found
+      extra.pattern = wanted
+    }
+    return this.ok(s.match, message, extra)
   }
 
   hasStrict (found, wanted, message, extra) {

--- a/tap-snapshots/test-test.js-TAP.test.cjs
+++ b/tap-snapshots/test-test.js-TAP.test.cjs
@@ -906,6 +906,66 @@ ok 1 - parent # {time}
 
 `
 
+exports[`test/test.js TAP assertions and weird stuff has > output 1`] = `
+TAP version 13
+ok 1 - should pass
+not ok 2 - should fail
+  ---
+  at:
+    line: #
+    column: #
+    file: test/test.js
+  diff: |
+    --- expected
+    +++ actual
+    @@ -1,4 +1,3 @@
+     Object {
+       "a": "b",
+    -  "b": 1,
+     }
+  source: |2
+          tt.has({ a: 'b', c: '1' }, { a: 'b', c: 1 }, 'should pass')
+          tt.has({ a: 'b', c: '1' }, { a: 'b', b: 1 }, 'should fail')
+    --^
+          tt.has({ a: 'b', c: 1 }, { a: 'b', c: Number }, 'should fail')
+          tt.has({ a: 1, b: 2, c: 3 }, { b: '2' }, 'should pass')
+  stack: |
+    {STACK}
+  ...
+
+not ok 3 - should fail
+  ---
+  at:
+    line: #
+    column: #
+    file: test/test.js
+  diff: |
+    --- expected
+    +++ actual
+    @@ -1,4 +1,4 @@
+     Object {
+       "a": "b",
+    -  "c": Function Number(),
+    +  "c": 1,
+     }
+  source: |2
+          tt.has({ a: 'b', c: '1' }, { a: 'b', b: 1 }, 'should fail')
+          tt.has({ a: 'b', c: 1 }, { a: 'b', c: Number }, 'should fail')
+    --^
+          tt.has({ a: 1, b: 2, c: 3 }, { b: '2' }, 'should pass')
+          tt.has({ a: 'b', c: '1' }, { a: 'b', c: 1 }, { todo: true })
+  stack: |
+    {STACK}
+  ...
+
+ok 4 - should pass
+ok 5 - should contain all provided fields # TODO
+1..5
+# failed 2 of 5 tests
+# todo: 1
+
+`
+
 exports[`test/test.js TAP assertions and weird stuff hasStrict > output 1`] = `
 TAP version 13
 not ok 1 - should fail

--- a/test/test.js
+++ b/test/test.js
@@ -344,6 +344,15 @@ t.test('assertions and weird stuff', t => {
       tt.end()
     },
 
+    has: tt => {
+      tt.has({ a: 'b', c: '1' }, { a: 'b', c: 1 }, 'should pass')
+      tt.has({ a: 'b', c: '1' }, { a: 'b', b: 1 }, 'should fail')
+      tt.has({ a: 'b', c: 1 }, { a: 'b', c: Number }, 'should fail')
+      tt.has({ a: 1, b: 2, c: 3 }, { b: '2' }, 'should pass')
+      tt.has({ a: 'b', c: '1' }, { a: 'b', c: 1 }, { todo: true })
+      tt.end()
+    },
+
     hasStrict: tt => {
       tt.hasStrict({ a: 'b', c: '1' }, { a: 'b', c: 1 }, 'should fail')
       tt.hasStrict({ a: 1, b: 2, c: 3 }, { b: 2 }, 'should pass')


### PR DESCRIPTION
t.has() is a way to test for the fields specified, _without_ fancy
regexps and type matching.

t.match() is a way to test for regexp matches, types, and lots of other
conveniences.

With this change, there's (finally) a direct 1:1 correlation between the
methods exported by tcompare and the associated tap assertion functions.