### PR TITLE
do not report only/grep filtered skips in test.lists

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -263,6 +263,11 @@ class Base extends MiniPass {
       this.lists.todo.push(res)
     })
     this.parser.on('skip', res => {
+      // it is uselessly noisy to print out lists of tests skipped
+      // because of a --grep or --only argument.
+      if (/^filter: (only|\/.*\/)$/.test(res.skip))
+        return
+
       this.counts.skip++
       this.lists.skip.push(res)
     })

--- a/tap-snapshots/test-base.js-TAP.test.cjs
+++ b/tap-snapshots/test-base.js-TAP.test.cjs
@@ -9,9 +9,9 @@ exports[`test/base.js TAP parser event stuff no bail > counts 1`] = `
 Object {
   "fail": 1,
   "pass": 1,
-  "skip": 1,
+  "skip": 2,
   "todo": 1,
-  "total": 4,
+  "total": 7,
 }
 `
 
@@ -35,6 +35,13 @@ Object {
       "name": "not so fine",
       "ok": false,
       "skip": "dont care for now",
+    },
+    Result {
+      "fullname": "",
+      "id": 7,
+      "name": "just a regular skip",
+      "ok": true,
+      "skip": "filter: some other thing",
     },
   ],
   "todo": Array [

--- a/test/base.js
+++ b/test/base.js
@@ -316,7 +316,10 @@ not ok 2 - actually not fine
   ...
 not ok 3 - not so fine # TODO will be fine later
 not ok 4 - not so fine # SKIP dont care for now
-1..4
+ok 5 - grep filtered test # SKIP filter: /grep/
+ok 6 - only filtered test # SKIP filter: only
+ok 7 - just a regular skip # SKIP filter: some other thing
+1..7
 `
 
   t.test('no bail', t => {


### PR DESCRIPTION
This allows us to not report on them more easily.  Otherwise,
using 'tap -g' on a big test prints a ton of garbage, and the
whole point of using '-g' is to focus on one thing.