### PR TITLE
Create test.snapshotFilename method

### DIFF
--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -9,11 +9,7 @@ class Snapshot {
     this.indexes = new Map()
     this.test = test
     // name them .test.cjs so that nyc ignores them
-    this.file = path.resolve(
-      cwd,
-      'tap-snapshots',
-      this.test.fullname.trim().replace(/[^a-zA-Z0-9\._\-]+/g, '-')
-    ) + '.test.cjs'
+    this.file = test.snapshotFilename('.test.cjs');
     this.snapshot = null
   }
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -1194,8 +1194,9 @@ class Test extends Base {
     return path.resolve(
       cwd,
       'tap-snapshots',
-      this.fullname.trim().replace(/[^a-zA-Z0-9\._\-]+/g, '-')
-    ) + suffix;
+      (this.fullname.trim() + suffix)
+        .replace(/[^a-zA-Z0-9\._\-]+/g, '-')
+    );
   }
 
   testdir (fixture) {

--- a/lib/test.js
+++ b/lib/test.js
@@ -1190,6 +1190,14 @@ class Test extends Base {
       (this.name || 'unnamed test').replace(re, '-')
   }
 
+  snapshotFilename(suffix) {
+    return path.resolve(
+      cwd,
+      'tap-snapshots',
+      this.fullname.trim().replace(/[^a-zA-Z0-9\._\-]+/g, '-')
+    ) + suffix;
+  }
+
   testdir (fixture) {
     const {rmdirRecursiveSync} = settings
     const dir = this.testdirName

--- a/test/test.js
+++ b/test/test.js
@@ -1297,6 +1297,12 @@ t.test('test dir name does not throw when no main module is present', t => {
   })
 })
 
+t.test('snapshot file name', t => {
+  const snapshotDir = path.resolve(__dirname, '..', 'tap-snapshots', 'test-test.js-TAP-snapshot-file-name.txt')
+  t.equal(t.snapshotFilename('.txt'), snapshotDir)
+  t.end()
+})
+
 t.test('fixture dir stuff', t => {
   const tdn = t.testdirName
   t.throws(() => fs.statSync(tdn), 'doesnt exist yet')


### PR DESCRIPTION
This makes it possible to generate a filename based on the current test
stored in the `tap-snapshots` folder.