### PR TITLE
prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## 1.0.0-0
+
+### Breaking Changes
+
+* Run fixture cleanup asynchronously, after teardown
+* Remove callback from beforeEach / afterEach
+* Improve tap-snapshot folder structure
+* Inherit t.saveFixture boolean
+
+### Features
+
+* Create fixture symlinks as junctions if pointing at directories
+* Add tap-testdir- to the generated test dir folder
+* Add `t.mock()` API
+* Add `t.before(fn)` API
+* beforEach / afterEach can return promises
+* Separate `t.match` and `t.has`
+* Add `t.notHas()` / `t.notHasStrict()` API's
+* Support `t.compareOptions` for configuring tcompare behavior
+* Resolve child test promise to results
+* Do not report only/grep filtered skips in test.lists
+* Make snapshot file location fully customizable
+
+
 ## 0.3.0
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ### Breaking Changes
 
 * Run fixture cleanup asynchronously, after teardown
-* Remove callback from beforeEach / afterEach
+* beforeEach / afterEach no longer received a callback, are assumed to be synchronous
+  if they do not return a promise
 * Improve tap-snapshot folder structure
 * Inherit t.saveFixture boolean
 
@@ -13,7 +14,6 @@
 * Add tap-testdir- to the generated test dir folder
 * Add `t.mock()` API
 * Add `t.before(fn)` API
-* beforEach / afterEach can return promises
 * Separate `t.match` and `t.has`
 * Add `t.notHas()` / `t.notHasStrict()` API's
 * Support `t.compareOptions` for configuring tcompare behavior

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0-0
+## 1.0.0
 
 ### Breaking Changes
 

--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ edge cases it can be appropriate to use `libtap` directly.
 
 ### Recursive rmdir
 
-Some parts of `libtap` require a recursive rmdirSync function.  In Node.js 12.10.0+
-the default implementation is `dir => fs.rmdirSync(dir, {recursive: true})`.  For older
-versions of Node.js you must set `require('libtap/settings').rmdirRecursiveSync` with a
-compatible function.  This function must be synchronous and have a single parameter:
+Some parts of `libtap` require recursive rmdir functions.  In Node.js 12.10.0+
+this is provided by the Node.js core `fs` module.  For older versions of Node.js you
+must set compatible functions:
 
 ```js
-const rimraf = require('rimraf').sync
+const rimraf = require('rimraf')
 const settings = require('libtap/settings')
-settings.rmdirRecursiveSync = dir => rimraf(dir, {glob: false})
+settings.rmdirRecursiveSync = dir => rimraf.sync(dir, {glob: false})
+settings.rmdirRecursive = (dir, cb) => rimraf(dir, {glob: false}, cb)
 ```
 
 This is handled by `tap` so only direct users of `libtap` who need to support older


### PR DESCRIPTION
@isaacs this is what I'm planning for release notes.  Obviously as is this will happen after #34.

Side question do you think this should have a 1.0.0-0 release or just go straight to 1.0.0?  Maybe we just tag 1.0.0 as `next` for now so we still have the option of breaking changes if needed?