### PR TITLE
fix: join testdirName with path.sep instead of /

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -1191,7 +1191,7 @@ class Test extends Base {
       const dir = path.dirname(main)
       const base = 'tap-testdir-' + (path.basename(main).replace(/\.[^.]+$/, '')
         + ' ' + process.argv.slice(2).join(' ')).trim()
-      return dir + '/' + base.replace(re, '-')
+      return dir + path.sep + base.replace(re, '-')
     }
 
     return this.parent.testdirName + '-' +


### PR DESCRIPTION
using a `/` makes it so `t.testdir()` returns a path with mixed separators in Windows, this change makes it so that it will not do that any more