### PR TITLE
Improve error messages reported by `t.resolves()`

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -1732,7 +1732,16 @@ class Test extends Base {
 
     return this.waitOn(promise, w => {
       extra.found = w.value
-      this.ok(w.resolved, message, extra)
+      if (w.resolved) {
+        this.pass(message, extra)
+        return
+      }
+
+      // Implementation based on doesNotThrow()
+      const er = w.value;
+      const e = extraFromError(er, extra);
+      e.message = er.message;
+      this.fail(message, e);
     })
   }
 

--- a/tap-snapshots/test/test.js.test.cjs
+++ b/tap-snapshots/test/test.js.test.cjs
@@ -2394,12 +2394,15 @@ not ok 6 - expect resolving Promise
     message: ouch
     stack: |
       {STACK}
+  message: ouch
   source: |2
           tt.resolves(() => {}, 'fail: no promise')
           tt.resolves(() => Promise.reject(new Error('ouch')))
     --^
           tt.resolves(() => Promise.reject('ouch string'))
           tt.end()
+  stack: |
+    {STACK}
   ...
 
 not ok 7 - expect resolving Promise
@@ -2408,7 +2411,9 @@ not ok 7 - expect resolving Promise
     line: #
     column: #
     file: test/test.js
+  error: ouch string
   found: ouch string
+  message: null
   source: |2
           tt.resolves(() => Promise.reject(new Error('ouch')))
           tt.resolves(() => Promise.reject('ouch string'))

--- a/tap-snapshots/test/test.js.test.cjs
+++ b/tap-snapshots/test/test.js.test.cjs
@@ -2378,12 +2378,47 @@ not ok 5 - fail: no promise
           tt.resolves(() => new Promise(r => r(420)), 'passing promise fn')
           tt.resolves(() => {}, 'fail: no promise')
     --^
+          tt.resolves(() => Promise.reject(new Error('ouch')))
+          tt.resolves(() => Promise.reject('ouch string'))
+  ...
+
+not ok 6 - expect resolving Promise
+  ---
+  at:
+    line: #
+    column: #
+    file: test/test.js
+  found:
+    !error
+    name: Error
+    message: ouch
+    stack: |
+      {STACK}
+  source: |2
+          tt.resolves(() => {}, 'fail: no promise')
+          tt.resolves(() => Promise.reject(new Error('ouch')))
+    --^
+          tt.resolves(() => Promise.reject('ouch string'))
+          tt.end()
+  ...
+
+not ok 7 - expect resolving Promise
+  ---
+  at:
+    line: #
+    column: #
+    file: test/test.js
+  found: ouch string
+  source: |2
+          tt.resolves(() => Promise.reject(new Error('ouch')))
+          tt.resolves(() => Promise.reject('ouch string'))
+    --^
           tt.end()
         },
   ...
 
-1..5
-# failed 1 of 5 tests
+1..7
+# failed 3 of 7 tests
 # todo: 1
 
 `

--- a/test/test.js
+++ b/test/test.js
@@ -622,6 +622,8 @@ t.test('assertions and weird stuff', t => {
       tt.resolves(new Promise(r => r(420)), 'passing promise')
       tt.resolves(() => new Promise(r => r(420)), 'passing promise fn')
       tt.resolves(() => {}, 'fail: no promise')
+      tt.resolves(() => Promise.reject(new Error('ouch')))
+      tt.resolves(() => Promise.reject('ouch string'))
       tt.end()
     },
 


### PR DESCRIPTION
When compared to `t.doesNowThrow()`, `t.resolves()` reports a different and less helpful error when the Promise is rejected

When the promise passed to `t.resolves()` is rejected:

Before this change, the test would fail with a generic error message

```
 ✖ expect resolving Promise
```

This is rather unhelpful, as the underlying error with details about the actual cause is hidden from the user. Also the error location is pointing to `t.resolves()`.

```
  2 |
  3 | test('resolve-reject', async (t) => {
> 4 |   await t.resolves(Promise.reject(new Error('rejection')));
    | ----^
  5 | });
```

In this commit, I have reworked the implementation of `t.resolves()` to use the same solution as in `t.doesNotThrow()` and call `t.fail()` when the Promise was rejected.

As a result, information about the original error is lifted up and the error location is pointing to the place where the original error was created.

```
  2 |
  3 | test('resolve-reject', async (t) => {
> 4 |   await t.resolves(Promise.reject(new Error('rejection')));
    | ----------------------------^
  5 | });
```

To make this pull request easier to review, I split it into two commits:
1. The first commit adds two new snapshot-based unit tests to document the current behaviour.
2. The second commit makes the proposed changes.

Personally, I would like tap to include error details in the test failure message. At the moment, `tap -R cov` prints only `Error: expect resolving Promise`.

```
my-test.js
  resolve-reject
    1) expect resolving Promise

  does-not-throw
    2) expected to not throw
```

One has to use the default reporter and inspect the failure details to figure out what happened. However, I think such improvements are out of the scope of this pull request unless you prefer to skip this incremental improvement and go straight for a better experience? 

I would also appreciate it if you could share some hints on what's the right way to report the actual error message instead (or in addition) to the default `expect resolving Promise` message.