### PR TITLE
teardown in reverse order

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -925,7 +925,7 @@ class Test extends Base {
   }
 
   teardown (fn) {
-    this.onTeardown.push(fn)
+    this.onTeardown.unshift(fn)
   }
 
   shouldAutoend () {

--- a/tap-snapshots/test/test.js.test.cjs
+++ b/tap-snapshots/test/test.js.test.cjs
@@ -2580,6 +2580,19 @@ not ok 2 - expect never emitted event to be emitted
 
 `
 
+exports[`test/test.js TAP assertions and weird stuff teardown in reverse order > output 1`] = `
+TAP version 13
+# Subtest: parent
+    ok 1 - this is fine
+    1..1
+ok 1 - parent # {time}
+
+# second teardown
+# first teardown
+1..1
+
+`
+
 exports[`test/test.js TAP assertions and weird stuff teardown promise > output 1`] = `
 TAP version 13
 # Subtest: parent

--- a/test/test.js
+++ b/test/test.js
@@ -768,6 +768,20 @@ t.test('assertions and weird stuff', t => {
       tt.end()
     },
 
+    'teardown in reverse order': tt => {
+      tt.test('parent', tt => {
+        tt.teardown(() => {
+          tt.comment('first teardown')
+        })
+        tt.teardown(() => {
+          tt.comment('second teardown')
+        })
+        tt.pass('this is fine')
+        tt.end()
+      })
+      tt.end()
+    },
+
     'fullname without main': tt => {
       const main = process.argv[1]
       process.argv[1] = ''


### PR DESCRIPTION
Run the teardown hooks in the reverse order they were registered.

Fixes https://github.com/tapjs/node-tap/issues/695
